### PR TITLE
Add navbar to all pages and virus dropdown menu

### DIFF
--- a/Html/Appointment.html
+++ b/Html/Appointment.html
@@ -21,57 +21,67 @@
 
 <body class="body">
     <!-- Navbar -->
-    <nav class="navbar navbar-expand-lg  text-white fixed-top">
-        <div class="container-fluid"><a href="Home.html">
-                <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
-                aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-                <div class="main">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-                        <h1>Vertex Systems</h1>
-                </div>
-                <div class="hab">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="About.html">About</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="Services.html">Help</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
-                        </li>
-                    </ul>
-                </div>
-
-
-                <!-- Sign up & Login -->
-                <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                    <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
-                    </li>
-                    <li class="Signup">
-                        <a class="nav-link active" aria-current="page" href="Signup.html">Sign up</a>
-                    </li>
-                </ul>
-            </div>
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <div class="main">
+          <h1>Vertex Systems</h1>
         </div>
+        <div class="hab">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="About.html">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Services.html">Help</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
+            </li>
+          </ul>
         </div>
-    </nav>
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
+          </li>
+          <li class="Signup">
+            <a class="nav-link active" aria-current="page" href="Signup.html">Sign up</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
 
     <br><br><br><br>
     <!-- Main Heading -->

--- a/Html/COVID-19.html
+++ b/Html/COVID-19.html
@@ -23,42 +23,56 @@
 <body class="primary-subtle">
 
      <!-- navbar -->
-  <nav class="navbar navbar-expand-lg  text-white fixed-top">
-    <div class="container-fluid"><a href="Home.html">
-        <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-       
         <div class="main">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-<h1>Vertex Systems</h1>
+          <h1>Vertex Systems</h1>
         </div>
         <div class="hab">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="About.html">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Services.html">Services</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
-          </li>
-          
-        </ul>
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="About.html">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Services.html">Help</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
+            </li>
+          </ul>
         </div>
-
-        
-        <!-- Sign up & Login -->
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
@@ -68,7 +82,6 @@
           </li>
         </ul>
       </div>
-    </div>
     </div>
   </nav>
 

--- a/Html/Common Cold.html
+++ b/Html/Common Cold.html
@@ -23,42 +23,56 @@
 <body class="primary-subtle">
 
    <!-- navbar -->
-  <nav class="navbar navbar-expand-lg  text-white fixed-top">
-    <div class="container-fluid"><a href="Home.html">
-        <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-       
         <div class="main">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-<h1>Vertex Systems</h1>
+          <h1>Vertex Systems</h1>
         </div>
         <div class="hab">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="About.html">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Services.html">Services</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
-          </li>
-          
-        </ul>
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="About.html">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Services.html">Help</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
+            </li>
+          </ul>
         </div>
-
-        
-        <!-- Sign up & Login -->
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
@@ -68,7 +82,6 @@
           </li>
         </ul>
       </div>
-    </div>
     </div>
   </nav>
 

--- a/Html/Contact.html
+++ b/Html/Contact.html
@@ -21,20 +21,20 @@
 
 <body class="body">
     <!-- Navbar -->
-    <nav class="navbar navbar-expand-lg  text-white fixed-top">
-      <div class="container-fluid"><a href="Home.html">
-          <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-         
-          <div class="main">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-  <h1>Vertex Systems</h1>
-          </div>
-          <div class="hab">
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <div class="main">
+          <h1>Vertex Systems</h1>
+        </div>
+        <div class="hab">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
@@ -51,24 +51,37 @@
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
             </li>
-            
-          </ul>
-          </div>
-  
-          
-          <!-- Sign up & Login -->
-          <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
             <li class="nav-item">
-              <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
             </li>
-            <li class="Signup">
-              <a class="nav-link active" aria-current="page" href="Signup.html">Sign up</a>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
             </li>
           </ul>
         </div>
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
+          </li>
+          <li class="Signup">
+            <a class="nav-link active" aria-current="page" href="Signup.html">Sign up</a>
+          </li>
+        </ul>
       </div>
-      </div>
-    </nav>
+    </div>
+  </nav>
   
     <br><br><br><br>
 

--- a/Html/HIV.html
+++ b/Html/HIV.html
@@ -23,42 +23,56 @@
 <body class="primary-subtle">
 
      <!-- navbar -->
-  <nav class="navbar navbar-expand-lg  text-white fixed-top">
-    <div class="container-fluid"><a href="Home.html">
-        <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-       
         <div class="main">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-<h1>Vertex Systems</h1>
+          <h1>Vertex Systems</h1>
         </div>
         <div class="hab">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="About.html">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Services.html">Services</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
-          </li>
-          
-        </ul>
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="About.html">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Services.html">Help</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
+            </li>
+          </ul>
         </div>
-
-        
-        <!-- Sign up & Login -->
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
@@ -68,7 +82,6 @@
           </li>
         </ul>
       </div>
-    </div>
     </div>
   </nav>
 

--- a/Html/Hepatitis B.html
+++ b/Html/Hepatitis B.html
@@ -23,42 +23,56 @@
 <body class="primary-subtle">
 
      <!-- navbar -->
-    <nav class="navbar navbar-expand-lg  text-white fixed-top">
-    <div class="container-fluid"><a href="Home.html">
-        <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-       
         <div class="main">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-<h1>Vertex Systems</h1>
+          <h1>Vertex Systems</h1>
         </div>
         <div class="hab">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="About.html">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Services.html">Services</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
-          </li>
-          
-        </ul>
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Home.html">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="About.html">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Services.html">Help</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Contact.html">Contact</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
+            </li>
+          </ul>
         </div>
-
-        
-        <!-- Sign up & Login -->
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
@@ -68,7 +82,6 @@
           </li>
         </ul>
       </div>
-    </div>
     </div>
   </nav>
 

--- a/Html/Services.html
+++ b/Html/Services.html
@@ -21,18 +21,18 @@
 
 <body class="body">
   <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg  text-white fixed-top">
-    <div class="container-fluid"><a href="Home.html">
-        <img src="download.jpg" class=" cat1 rounded-5" alt="error"></a>
+  <nav class="navbar navbar-expand-lg text-white fixed-top">
+    <div class="container-fluid">
+      <a href="Home.html">
+        <img src="download.jpg" class="cat1 rounded-5" alt="Vertex Systems logo">
+      </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
         <div class="main">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
-            <h1>Vertex Systems</h1>
+          <h1>Vertex Systems</h1>
         </div>
         <div class="hab">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0 text-center">
@@ -51,12 +51,26 @@
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="YearWiseList.html">YearWiseListing</a>
             </li>
-
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="Appointment.html">Appointment</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="virusDropdown" role="button" data-bs-toggle="dropdown"
+                aria-expanded="false">Types of Viruses</a>
+              <ul class="dropdown-menu virus-dropdown-menu" aria-labelledby="virusDropdown">
+                <li><a class="dropdown-item" href="influenza.html">Influenza (Flu)</a></li>
+                <li><a class="dropdown-item" href="COVID-19.html">COVID-19 (SARS-CoV-2)</a></li>
+                <li><a class="dropdown-item" href="Common Cold.html">Common Cold</a></li>
+                <li><a class="dropdown-item" href="HIV.html">HIV</a></li>
+                <li><a class="dropdown-item" href="Hepatitis B.html">Hepatitis B</a></li>
+                <li><a class="dropdown-item" href="Hepatitis C.html">Hepatitis C</a></li>
+                <li><a class="dropdown-item" href="herps.html">Herpes Simplex Virus</a></li>
+                <li><a class="dropdown-item" href="Human Papillomavirus.html">Human Papillomavirus</a></li>
+                <li><a class="dropdown-item" href="Varicella-Zoster Virus.html">Varicella-Zoster Virus</a></li>
+              </ul>
+            </li>
           </ul>
         </div>
-
-
-        <!-- Sign up & Login -->
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="Login.htm">Login</a>
@@ -66,7 +80,6 @@
           </li>
         </ul>
       </div>
-    </div>
     </div>
   </nav>
 


### PR DESCRIPTION
## Purpose
Standardize the navigation experience across the website by adding the consistent navbar from home.html to all HTML pages (excluding signup and login pages). Enhance user navigation by adding a dropdown menu for virus types and improve overall website responsiveness.

## Code changes
- **Navbar standardization**: Updated navbar structure in Appointment.html, COVID-19.html, Hepatitis B.html, and Services.html to match the home page layout
- **New dropdown menu**: Added "Types of Viruses" dropdown with links to 9 virus-specific pages (Influenza, COVID-19, Common Cold, HIV, Hepatitis B, Hepatitis C, Herpes Simplex, HPV, Varicella-Zoster)
- **Navigation improvements**: Added missing "Appointment" link to navbar across pages and standardized "Services" to "Help" for consistency
- **Code cleanup**: Improved HTML formatting and indentation, removed redundant div elements, and enhanced alt text for accessibility
- **Link corrections**: Fixed navigation links and ensured proper Bootstrap dropdown functionalityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/76a219ba6ab842deb47edfdadde47fcd/zenith-zone)

👀 [Preview Link](https://76a219ba6ab842deb47edfdadde47fcd-zenith-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>76a219ba6ab842deb47edfdadde47fcd</projectId>-->
<!--<branchName>zenith-zone</branchName>-->